### PR TITLE
feat: add trap_exit to mission GenServer

### DIFF
--- a/lib/overmind/mission.ex
+++ b/lib/overmind/mission.ex
@@ -116,6 +116,7 @@ defmodule Overmind.Mission do
     restart_policy: restart_policy, max_restarts: max_restarts, max_seconds: max_seconds,
     backoff_ms: backoff_ms, activity_timeout: activity_timeout, parent: parent
   }) do
+    Process.flag(:trap_exit, true)
     port_command = build_port_command(type, provider, command)
     port_opts = [:binary, :exit_status, :stderr_to_stdout] ++ build_env(id, name) ++ maybe_cd(cwd)
     port = Port.open({:spawn, port_command}, port_opts)
@@ -318,6 +319,13 @@ defmodule Overmind.Mission do
          activity_timer_ref: activity_timer_ref,
          last_activity_at: last_activity_at
      }}
+  end
+
+  # Port link sends {:EXIT, port, reason} on port death. Already handled
+  # by exit_status — ignore to prevent GenServer crash when trapping exits.
+  @impl true
+  def handle_info({:EXIT, _pid, _reason}, state) do
+    {:noreply, state}
   end
 
   @impl true

--- a/test/overmind/mission_test.exs
+++ b/test/overmind/mission_test.exs
@@ -976,6 +976,20 @@ defmodule Overmind.MissionTest do
     end
   end
 
+  describe "trap_exit" do
+    test "terminate persists logs to ETS on GenServer shutdown" do
+      Process.flag(:trap_exit, true)
+      id = Mission.generate_id()
+      {:ok, pid} = Mission.start_link(id: id, command: "sh -c 'echo hello; sleep 60'")
+      Process.sleep(100)
+      ref = Process.monitor(pid)
+      Process.exit(pid, :shutdown)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :shutdown}, 1000
+
+      assert Overmind.Mission.Store.stored_logs(id) =~ "hello"
+    end
+  end
+
   describe "exit detection" do
     test "exit 0 sets :stopped status in ETS" do
       id = Mission.generate_id()


### PR DESCRIPTION
Closes #15

## Summary

Mission GenServer didn't call `Process.flag(:trap_exit, true)`, so `terminate/1` never fired on GenServer crash. Accumulated logs and raw_events in the GenServer struct were silently lost. This was inconsistent with Blueprint.Runner which already traps exits.

Adding trap_exit ensures `Store.persist_after_exit/3` runs on shutdown, preserving mission state in ETS. This is a prerequisite for OTP-level restart (#14) where the supervisor brings up a new GenServer that recovers state from ETS.

## Changes

- Added `Process.flag(:trap_exit, true)` in `Mission.init/1`
- Added catch-all `handle_info({:EXIT, _, _})` to ignore port link signals (already handled by `exit_status`)
- Test proving logs persist to ETS when GenServer is shutdown externally

## Testing

- [x] `mix test` passes (302 tests)
- [x] `mix dialyzer` passes
- [x] `mix smoke` passes